### PR TITLE
Add customizable 4x6 PDF label layout with preview and barcode inset controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;700&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.0/dist/JsBarcode.all.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@4.5.136/build/pdf.min.js"></script>
     <style>
         body {
             font-family: 'Noto Sans TC', sans-serif;
@@ -75,43 +74,53 @@
         <div>
             <button onclick="generateBarcode()">產生條碼</button>
             <a id="download-link" download="barcode.svg" style="display:none;"><button>下載 SVG</button></a>
-            <button id="download-pdf-button" onclick="downloadLabelPdf()" style="display:none;">下載 4x6 標籤 PDF（11x35mm）</button>
         </div>
         <hr style="margin: 24px 0;" />
-        <div>
-            <div style="margin-bottom: 10px;">自訂檔案排版到 4x6（102mm x 152mm）</div>
-            <input id="custom-file-input" type="file" accept=".png,.jpg,.jpeg,.webp,.svg,.ai,image/*" style="width:auto;margin-bottom:10px;" />
-            <div style="margin-bottom: 10px;">
-                <label for="use-custom-size">
-                    <input id="use-custom-size" type="checkbox" onchange="toggleCustomSizeMode()" />
-                    啟用自訂尺寸
-                </label>
+        <div style="text-align:left;max-width:520px;margin:0 auto 8px;">
+            <div style="margin-bottom: 10px;">下載 4x6 標籤 PDF（102mm x 152mm）</div>
+            <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+                <label for="label-width-mm">寬(mm)</label>
+                <input id="label-width-mm" type="number" min="5" max="102" step="0.1" placeholder="例如 35" value="35" style="width:90px;margin:0;" oninput="onLabelSettingsChanged()" />
+                <label for="label-height-mm">高(mm)</label>
+                <input id="label-height-mm" type="number" min="5" max="152" step="0.1" placeholder="例如 11" value="11" style="width:90px;margin:0;" oninput="onLabelSettingsChanged()" />
+            </div>
+            <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+                <span>條碼內縮</span>
+                <button type="button" onclick="adjustBarcodeInset(0.2)">－</button>
+                <span id="barcode-inset-display">0.6 mm</span>
+                <button type="button" onclick="adjustBarcodeInset(-0.2)">＋</button>
+                <span style="font-size:12px;color:#718096;">（預設 11 x 35）</span>
+            </div>
+            <div style="font-size:12px;color:#4a5568;margin-bottom:10px;">
+                目前可排版：<span id="layout-count-preview">0 欄 × 0 列</span>
             </div>
             <div style="margin-bottom: 10px;">
-                <label for="custom-width-mm">寬(mm)</label>
-                <input id="custom-width-mm" type="number" min="1" step="0.1" style="width:90px;margin:0 8px;" disabled />
-                <label for="custom-height-mm">高(mm)</label>
-                <input id="custom-height-mm" type="number" min="1" step="0.1" style="width:90px;margin-left:8px;" disabled />
-                <button id="preset-11x35-button" type="button" onclick="setPresetStickerSize()" style="margin-left:8px;display:none;">套用 11x35</button>
+                <button id="download-pdf-button" onclick="downloadLabelPdf()" style="display:none;">下載 4x6 標籤 PDF</button>
             </div>
-            <button onclick="downloadCustomLayoutPdf()">上傳檔案並排版成 4x6 PDF</button>
+            <div style="font-size:12px;color:#4a5568;margin-bottom:6px;">預覽（外框為貼紙尺寸）</div>
+            <div id="label-preview-shell" style="border:1px dashed #a0aec0;background:#f7fafc;padding:12px;width:max-content;">
+                <div id="label-preview-box" style="width:210px;height:66px;background:#fff;border:1px solid #2d3748;display:flex;align-items:center;justify-content:center;overflow:hidden;position:relative;">
+                    <div id="label-preview-content" style="display:flex;align-items:center;justify-content:center;position:absolute;">
+                        <img id="label-preview-image" alt="條碼預覽" style="width:100%;height:100%;object-fit:contain;display:none;" />
+                    </div>
+                    <span id="label-preview-placeholder" style="font-size:12px;color:#a0aec0;">先按「產生條碼」</span>
+                </div>
+            </div>
         </div>
         <div id="checksum-display"></div>
         <svg id="barcode"></svg>
         <footer>Generated with JsBarcode</footer>
     </div>
 <script>
-if (window.pdfjsLib && window.pdfjsLib.GlobalWorkerOptions) {
-    window.pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.5.136/build/pdf.worker.min.js';
-}
+const PAGE_WIDTH_MM = 102;
+const PAGE_HEIGHT_MM = 152;
+const DEFAULT_INSET_MM = 0.6;
+let currentBarcodePngDataUrl = '';
+let barcodeInsetMm = DEFAULT_INSET_MM;
+
 window.addEventListener('DOMContentLoaded', () => {
-    document.getElementById('custom-file-input').addEventListener('change', async (event) => {
-        const file = event.target.files && event.target.files[0];
-        if (!file) {
-            return;
-        }
-        await applyAutoDetectedSize(file);
-    });
+    updateInsetDisplay();
+    onLabelSettingsChanged();
 });
 function handleEnter(e) {
     if(e.key === 'Enter') {
@@ -140,6 +149,7 @@ function generateBarcode() {
     }
     renderBarcode(input);
     const serializer = new XMLSerializer();
+    refreshPreviewBarcodePng();
     const svg = document.getElementById('barcode');
     const url = URL.createObjectURL(new Blob([serializer.serializeToString(svg)], { type: 'image/svg+xml' }));
     const link = document.getElementById('download-link');
@@ -213,231 +223,295 @@ async function downloadLabelPdf() {
         alert('請輸入 12 位數字');
         return;
     }
+    const label = getValidatedLabelSize(true);
+    if (!label) {
+        return;
+    }
     renderBarcode(input);
     const svg = document.getElementById('barcode');
     const { jsPDF } = window.jspdf;
-    const pageWidth = 102;
-    const pageHeight = 152;
-    const barcodeWidth = 35;
-    const barcodeHeight = 11;
+    const barcodeWidth = label.widthMm;
+    const barcodeHeight = label.heightMm;
     const pngDataUrl = await svgToCroppedPngDataUrl(svg, barcodeWidth, barcodeHeight);
-    const gap = 0;
+    currentBarcodePngDataUrl = pngDataUrl;
+    renderLabelPreview();
     const marginX = 0;
     const marginY = 0;
-    const cols = Math.floor((pageWidth - marginX * 2 + gap) / (barcodeWidth + gap));
-    const rows = Math.floor((pageHeight - marginY * 2 + gap) / (barcodeHeight + gap));
+    const layoutPlan = getLayoutPlan(barcodeWidth, barcodeHeight);
+    if (layoutPlan.totalCount <= 0) {
+        alert('尺寸太大，4x6 標籤紙放不下，請調整寬高');
+        return;
+    }
     const pdf = new jsPDF({
         orientation: 'portrait',
         unit: 'mm',
-        format: [pageWidth, pageHeight]
+        format: [PAGE_WIDTH_MM, PAGE_HEIGHT_MM]
     });
     pdf.setDrawColor(0, 0, 0);
     pdf.setLineWidth(0.2);
-    const safePaddingX = 0.6;
-    const safePaddingTop = 0.4;
-    const safePaddingBottom = 1.0;
-    const imageWidth = Math.max(1, barcodeWidth - safePaddingX * 2);
-    const imageHeight = Math.max(1, barcodeHeight - safePaddingTop - safePaddingBottom);
-    for (let row = 0; row < rows; row++) {
-        for (let col = 0; col < cols; col++) {
-            const x = marginX + col * (barcodeWidth + gap);
-            const y = marginY + row * (barcodeHeight + gap);
+    const maxInset = getMaxInset(barcodeWidth, barcodeHeight);
+    const safeInset = Math.min(Math.max(barcodeInsetMm, 0), maxInset);
+    const insets = getBarcodeInsetsMm(safeInset, barcodeWidth, barcodeHeight);
+    const imageWidth = Math.max(1, barcodeWidth - insets.left - insets.right);
+    const imageHeight = Math.max(1, barcodeHeight - insets.top - insets.bottom);
+    const normalImageSize = await getImageSizeFromDataUrl(pngDataUrl);
+    const normalPlacement = getContainPlacement(
+        normalImageSize.width,
+        normalImageSize.height,
+        imageWidth,
+        imageHeight
+    );
+    for (let row = 0; row < layoutPlan.portraitRows; row++) {
+        for (let col = 0; col < layoutPlan.portraitCols; col++) {
+            const x = marginX + col * barcodeWidth;
+            const y = marginY + row * barcodeHeight;
             pdf.addImage(
                 pngDataUrl,
                 'PNG',
-                x + safePaddingX,
-                y + safePaddingTop,
-                imageWidth,
-                imageHeight,
+                x + insets.left + normalPlacement.offsetX,
+                y + insets.top + normalPlacement.offsetY,
+                normalPlacement.drawWidth,
+                normalPlacement.drawHeight,
                 undefined,
                 'FAST'
             );
             pdf.rect(x, y, barcodeWidth, barcodeHeight);
         }
     }
+    if (layoutPlan.landscapeCols > 0 && layoutPlan.landscapeRows > 0) {
+        const rotatedPngDataUrl = await rotatePngDataUrl90(pngDataUrl);
+        const rotatedWidth = barcodeHeight;
+        const rotatedHeight = barcodeWidth;
+        const rotatedInsets = getBarcodeInsetsMm(safeInset, rotatedWidth, rotatedHeight);
+        const rotatedImageWidth = Math.max(1, rotatedWidth - rotatedInsets.left - rotatedInsets.right);
+        const rotatedImageHeight = Math.max(1, rotatedHeight - rotatedInsets.top - rotatedInsets.bottom);
+        const rotatedImageSize = await getImageSizeFromDataUrl(rotatedPngDataUrl);
+        const rotatedPlacement = getContainPlacement(
+            rotatedImageSize.width,
+            rotatedImageSize.height,
+            rotatedImageWidth,
+            rotatedImageHeight
+        );
+        for (let row = 0; row < layoutPlan.landscapeRows; row++) {
+            for (let col = 0; col < layoutPlan.landscapeCols; col++) {
+                const x = layoutPlan.landscapeStartX + col * rotatedWidth;
+                const y = row * rotatedHeight;
+                pdf.addImage(
+                    rotatedPngDataUrl,
+                    'PNG',
+                    x + rotatedInsets.left + rotatedPlacement.offsetX,
+                    y + rotatedInsets.top + rotatedPlacement.offsetY,
+                    rotatedPlacement.drawWidth,
+                    rotatedPlacement.drawHeight,
+                    undefined,
+                    'FAST'
+                );
+                pdf.rect(x, y, rotatedWidth, rotatedHeight);
+            }
+        }
+    }
     pdf.save(`barcode-4x6-${input}.pdf`);
 }
-function toggleCustomSizeMode() {
-    const enabled = document.getElementById('use-custom-size').checked;
-    const widthInput = document.getElementById('custom-width-mm');
-    const heightInput = document.getElementById('custom-height-mm');
-    widthInput.disabled = !enabled;
-    heightInput.disabled = !enabled;
-    document.getElementById('preset-11x35-button').style.display = enabled ? 'inline-block' : 'none';
-}
-function setPresetStickerSize() {
-    document.getElementById('custom-width-mm').value = '35';
-    document.getElementById('custom-height-mm').value = '11';
-}
-function fileToDataUrl(file) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-    });
-}
-function fileToArrayBuffer(file) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = reject;
-        reader.readAsArrayBuffer(file);
-    });
-}
-function dataUrlToPngDataUrl(dataUrl) {
+function rotatePngDataUrl90(dataUrl) {
     return new Promise((resolve, reject) => {
         const image = new Image();
         image.onload = () => {
             const canvas = document.createElement('canvas');
-            canvas.width = image.width;
-            canvas.height = image.height;
+            canvas.width = image.height;
+            canvas.height = image.width;
             const ctx = canvas.getContext('2d');
             ctx.fillStyle = '#ffffff';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.drawImage(image, 0, 0);
+            ctx.translate(canvas.width / 2, canvas.height / 2);
+            ctx.rotate(Math.PI / 2);
+            ctx.drawImage(image, -image.width / 2, -image.height / 2);
             resolve(canvas.toDataURL('image/png'));
         };
         image.onerror = reject;
         image.src = dataUrl;
     });
 }
-function extractPdfBytesFromAi(arrayBuffer) {
-    const bytes = new Uint8Array(arrayBuffer);
-    const pdfHeader = [0x25, 0x50, 0x44, 0x46, 0x2d]; // %PDF-
-    let headerIndex = -1;
-    for (let i = 0; i <= bytes.length - pdfHeader.length; i++) {
-        let matched = true;
-        for (let j = 0; j < pdfHeader.length; j++) {
-            if (bytes[i + j] !== pdfHeader[j]) {
-                matched = false;
-                break;
+function getImageSizeFromDataUrl(dataUrl) {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve({ width: image.width, height: image.height });
+        image.onerror = reject;
+        image.src = dataUrl;
+    });
+}
+function getContainPlacement(sourceWidth, sourceHeight, boxWidth, boxHeight) {
+    const sourceRatio = sourceWidth / sourceHeight;
+    const boxRatio = boxWidth / boxHeight;
+    let drawWidth = boxWidth;
+    let drawHeight = boxHeight;
+    if (sourceRatio > boxRatio) {
+        drawHeight = boxWidth / sourceRatio;
+    } else {
+        drawWidth = boxHeight * sourceRatio;
+    }
+    return {
+        drawWidth,
+        drawHeight,
+        offsetX: (boxWidth - drawWidth) / 2,
+        offsetY: (boxHeight - drawHeight) / 2
+    };
+}
+function getBarcodeInsetsMm(baseInsetMm, labelWidthMm, labelHeightMm) {
+    const sideInset = Math.max(0, baseInsetMm);
+    const topInset = Math.max(0.3, 0.9 - baseInsetMm * 0.5);
+    const bottomInset = Math.max(0.3, baseInsetMm + 0.2);
+    const maxHorizontal = Math.max(0, labelWidthMm / 2 - 0.5);
+    const maxVertical = Math.max(0, labelHeightMm - 1);
+    const clampedSide = Math.min(sideInset, maxHorizontal);
+    const totalVertical = topInset + bottomInset;
+    let finalTop = topInset;
+    let finalBottom = bottomInset;
+    if (totalVertical > maxVertical) {
+        const scale = maxVertical / totalVertical;
+        finalTop *= scale;
+        finalBottom *= scale;
+    }
+    return {
+        left: clampedSide,
+        right: clampedSide,
+        top: finalTop,
+        bottom: finalBottom
+    };
+}
+function getValidatedLabelSize(showAlert = false) {
+    const widthMm = parseFloat(document.getElementById('label-width-mm').value);
+    const heightMm = parseFloat(document.getElementById('label-height-mm').value);
+    if (!widthMm || !heightMm || widthMm <= 0 || heightMm <= 0 || widthMm > PAGE_WIDTH_MM || heightMm > PAGE_HEIGHT_MM) {
+        if (showAlert) {
+            alert(`請輸入有效尺寸，寬高需在 0 ~ ${PAGE_WIDTH_MM}/${PAGE_HEIGHT_MM} mm 範圍內`);
+        }
+        return null;
+    }
+    return { widthMm, heightMm };
+}
+function refreshPreviewBarcodePng() {
+    const input = getBarcodeValue();
+    const label = getValidatedLabelSize();
+    if (!input || !label) {
+        currentBarcodePngDataUrl = '';
+        renderLabelPreview();
+        return;
+    }
+    renderBarcode(input);
+    const svg = document.getElementById('barcode');
+    svgToCroppedPngDataUrl(svg, label.widthMm, label.heightMm)
+        .then((pngDataUrl) => {
+            currentBarcodePngDataUrl = pngDataUrl;
+            renderLabelPreview();
+        })
+        .catch(() => {
+            currentBarcodePngDataUrl = '';
+            renderLabelPreview();
+        });
+}
+function updateInsetDisplay() {
+    document.getElementById('barcode-inset-display').textContent = `${barcodeInsetMm.toFixed(1)} mm`;
+}
+function getMaxInset(widthMm, heightMm) {
+    return Math.max(0, Math.min(widthMm, heightMm) / 2 - 0.5);
+}
+function adjustBarcodeInset(delta) {
+    const label = getValidatedLabelSize();
+    if (!label) {
+        return;
+    }
+    const maxInset = getMaxInset(label.widthMm, label.heightMm);
+    const nextInset = Math.min(maxInset, Math.max(0, barcodeInsetMm + delta));
+    barcodeInsetMm = Math.round(nextInset * 10) / 10;
+    updateInsetDisplay();
+    renderLabelPreview();
+}
+function onLabelSettingsChanged() {
+    const label = getValidatedLabelSize();
+    const layoutEl = document.getElementById('layout-count-preview');
+    if (!label) {
+        layoutEl.textContent = '0 欄 × 0 列';
+        renderLabelPreview();
+        return;
+    }
+    const plan = getLayoutPlan(label.widthMm, label.heightMm);
+    if (plan.landscapeCols > 0 && plan.landscapeRows > 0) {
+        layoutEl.textContent = `${plan.portraitCols} 欄 × ${plan.portraitRows} 列 + 橫式 ${plan.landscapeCols} 欄 × ${plan.landscapeRows} 列（總共 ${plan.totalCount} 張）`;
+    } else {
+        layoutEl.textContent = `${plan.portraitCols} 欄 × ${plan.portraitRows} 列（總共 ${plan.totalCount} 張）`;
+    }
+    const maxInset = getMaxInset(label.widthMm, label.heightMm);
+    if (barcodeInsetMm > maxInset) {
+        barcodeInsetMm = Math.round(maxInset * 10) / 10;
+        updateInsetDisplay();
+    }
+    refreshPreviewBarcodePng();
+}
+function getLayoutPlan(widthMm, heightMm) {
+    const portraitCols = Math.floor(PAGE_WIDTH_MM / widthMm);
+    const portraitRows = Math.floor(PAGE_HEIGHT_MM / heightMm);
+    let landscapeCols = 0;
+    let landscapeRows = 0;
+    let landscapeStartX = 0;
+    if (portraitCols > 0 && portraitRows > 0) {
+        const usedWidth = portraitCols * widthMm;
+        const remainWidth = PAGE_WIDTH_MM - usedWidth;
+        if (remainWidth >= heightMm) {
+            landscapeCols = Math.floor(remainWidth / heightMm);
+            landscapeRows = Math.floor(PAGE_HEIGHT_MM / widthMm);
+            if (landscapeCols > 0 && landscapeRows > 0) {
+                landscapeStartX = PAGE_WIDTH_MM - landscapeCols * heightMm;
+            } else {
+                landscapeCols = 0;
+                landscapeRows = 0;
             }
         }
-        if (matched) {
-            headerIndex = i;
-            break;
-        }
-    }
-    if (headerIndex === -1) {
-        throw new Error('找不到 PDF 內容');
-    }
-    return bytes.slice(headerIndex);
-}
-async function aiFileToPngDataUrl(file) {
-    if (!window.pdfjsLib) {
-        throw new Error('PDF 解析器尚未載入完成');
-    }
-    const arrayBuffer = await fileToArrayBuffer(file);
-    const pdfBytes = extractPdfBytesFromAi(arrayBuffer);
-    const loadingTask = window.pdfjsLib.getDocument({ data: pdfBytes });
-    const pdf = await loadingTask.promise;
-    const page = await pdf.getPage(1);
-    const viewport = page.getViewport({ scale: 2.5 });
-    const canvas = document.createElement('canvas');
-    canvas.width = Math.ceil(viewport.width);
-    canvas.height = Math.ceil(viewport.height);
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    await page.render({ canvasContext: ctx, viewport }).promise;
-    return canvas.toDataURL('image/png');
-}
-async function getFileNaturalSizePx(file) {
-    const fileName = (file.name || '').toLowerCase();
-    if (fileName.endsWith('.ai')) {
-        const arrayBuffer = await fileToArrayBuffer(file);
-        const pdfBytes = extractPdfBytesFromAi(arrayBuffer);
-        const loadingTask = window.pdfjsLib.getDocument({ data: pdfBytes });
-        const pdf = await loadingTask.promise;
-        const page = await pdf.getPage(1);
-        const viewport = page.getViewport({ scale: 1 });
-        return {
-            widthPx: viewport.width * (96 / 72),
-            heightPx: viewport.height * (96 / 72)
-        };
-    }
-    const rawDataUrl = await fileToDataUrl(file);
-    return await new Promise((resolve, reject) => {
-        const image = new Image();
-        image.onload = () => resolve({ widthPx: image.width, heightPx: image.height });
-        image.onerror = reject;
-        image.src = rawDataUrl;
-    });
-}
-async function applyAutoDetectedSize(file) {
-    const widthInput = document.getElementById('custom-width-mm');
-    const heightInput = document.getElementById('custom-height-mm');
-    try {
-        const naturalSize = await getFileNaturalSizePx(file);
-        const mmPerPx = 25.4 / 96;
-        widthInput.value = (naturalSize.widthPx * mmPerPx).toFixed(1);
-        heightInput.value = (naturalSize.heightPx * mmPerPx).toFixed(1);
-    } catch (error) {
-        widthInput.value = '';
-        heightInput.value = '';
-    }
-}
-async function downloadCustomLayoutPdf() {
-    const fileInput = document.getElementById('custom-file-input');
-    if (!fileInput.files || fileInput.files.length === 0) {
-        alert('請先選擇要排版的檔案');
-        return;
-    }
-    let widthMm = parseFloat(document.getElementById('custom-width-mm').value);
-    let heightMm = parseFloat(document.getElementById('custom-height-mm').value);
-    if (!widthMm || !heightMm) {
-        await applyAutoDetectedSize(fileInput.files[0]);
-        widthMm = parseFloat(document.getElementById('custom-width-mm').value);
-        heightMm = parseFloat(document.getElementById('custom-height-mm').value);
-    }
-    if (!widthMm || !heightMm || widthMm <= 0 || heightMm <= 0) {
-        alert('無法取得尺寸，請改勾選「啟用自訂尺寸」後手動輸入，或點「套用 11x35」。');
-        return;
-    }
-    const file = fileInput.files[0];
-    const fileName = (file.name || '').toLowerCase();
-    let dataUrl;
-    if (fileName.endsWith('.ai')) {
-        try {
-            dataUrl = await aiFileToPngDataUrl(file);
-        } catch (error) {
-            alert('AI 轉 PNG 失敗：請確認檔案為 PDF 相容的 AI，或改上傳 SVG/PNG。');
-            return;
-        }
     } else {
-        const rawDataUrl = await fileToDataUrl(file);
-        dataUrl = await dataUrlToPngDataUrl(rawDataUrl);
+        landscapeCols = Math.floor(PAGE_WIDTH_MM / heightMm);
+        landscapeRows = Math.floor(PAGE_HEIGHT_MM / widthMm);
     }
-    const pageWidth = 102;
-    const pageHeight = 152;
-    const gap = 0;
-    const marginX = 0;
-    const marginY = 0;
-    const cols = Math.floor((pageWidth - marginX * 2 + gap) / (widthMm + gap));
-    const rows = Math.floor((pageHeight - marginY * 2 + gap) / (heightMm + gap));
-    if (cols <= 0 || rows <= 0) {
-        alert('尺寸太大，4x6 標籤紙放不下，請調整寬高');
+    const totalCount = portraitCols * portraitRows + landscapeCols * landscapeRows;
+    return { portraitCols, portraitRows, landscapeCols, landscapeRows, landscapeStartX, totalCount };
+}
+function renderLabelPreview() {
+    const previewBox = document.getElementById('label-preview-box');
+    const previewContent = document.getElementById('label-preview-content');
+    const previewImage = document.getElementById('label-preview-image');
+    const placeholder = document.getElementById('label-preview-placeholder');
+    const label = getValidatedLabelSize();
+    if (!label) {
+        placeholder.textContent = '請輸入有效寬高';
+        placeholder.style.display = 'block';
+        previewImage.style.display = 'none';
+        previewContent.style.display = 'none';
         return;
     }
-    const { jsPDF } = window.jspdf;
-    const pdf = new jsPDF({
-        orientation: 'portrait',
-        unit: 'mm',
-        format: [pageWidth, pageHeight]
-    });
-    pdf.setDrawColor(0, 0, 0);
-    pdf.setLineWidth(0.2);
-    for (let row = 0; row < rows; row++) {
-        for (let col = 0; col < cols; col++) {
-            const x = marginX + col * (widthMm + gap);
-            const y = marginY + row * (heightMm + gap);
-            pdf.addImage(dataUrl, 'PNG', x, y, widthMm, heightMm, undefined, 'FAST');
-            pdf.rect(x, y, widthMm, heightMm);
-        }
+    const pxPerMm = 6;
+    const boxWidthPx = Math.round(label.widthMm * pxPerMm);
+    const boxHeightPx = Math.round(label.heightMm * pxPerMm);
+    previewBox.style.width = `${boxWidthPx}px`;
+    previewBox.style.height = `${boxHeightPx}px`;
+    const safeInset = Math.min(Math.max(barcodeInsetMm, 0), getMaxInset(label.widthMm, label.heightMm));
+    const insets = getBarcodeInsetsMm(safeInset, label.widthMm, label.heightMm);
+    const leftPx = Math.round(insets.left * pxPerMm);
+    const topPx = Math.round(insets.top * pxPerMm);
+    const rightPx = Math.round(insets.right * pxPerMm);
+    const bottomPx = Math.round(insets.bottom * pxPerMm);
+    previewContent.style.left = `${leftPx}px`;
+    previewContent.style.top = `${topPx}px`;
+    previewContent.style.width = `${Math.max(6, boxWidthPx - leftPx - rightPx)}px`;
+    previewContent.style.height = `${Math.max(6, boxHeightPx - topPx - bottomPx)}px`;
+    if (!currentBarcodePngDataUrl) {
+        placeholder.textContent = '先按「產生條碼」';
+        placeholder.style.display = 'block';
+        previewImage.style.display = 'none';
+        previewContent.style.display = 'none';
+        return;
     }
-    const safeName = (file.name || 'custom').replace(/\.[^.]+$/, '');
-    pdf.save(`layout-4x6-${safeName}.pdf`);
+    previewImage.src = currentBarcodePngDataUrl;
+    previewContent.style.display = 'flex';
+    previewImage.style.display = 'block';
+    placeholder.style.display = 'none';
 }
 function addHumanReadableText(svg, code) {
     const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');


### PR DESCRIPTION
### Motivation
- Improve the label PDF generation workflow to support arbitrary sticker sizes within a 4x6 (102×152 mm) sheet and provide a live preview before export. 
- Provide finer control over barcode placement inside a sticker by introducing an inset control and automatic safe padding calculations. 
- Remove the old file-upload/AI-to-PDF parsing flow and the `pdfjs-dist` dependency to simplify the UI and focus on direct barcode rendering and layout. 

### Description
- Added UI controls for label size (`label-width-mm`, `label-height-mm`), barcode inset adjustment, and a live layout count preview, plus a visual sticker preview shell. 
- Reworked `downloadLabelPdf()` to compute a `layoutPlan` for portrait and optional landscape placements, compute safe insets with `getBarcodeInsetsMm()`, and place images using `jsPDF` while supporting rotated placements by `rotatePngDataUrl90()`. 
- Implemented helper functions `getValidatedLabelSize()`, `getLayoutPlan()`, `getContainPlacement()`, `getImageSizeFromDataUrl()`, `getMaxInset()`, `adjustBarcodeInset()`, `refreshPreviewBarcodePng()`, and `renderLabelPreview()` to power previewing, sizing validation, inset/clamping and PDF placement math. 
- Removed `pdfjs-dist` usage and the AI/SVG/PNG auto-detection/AI parsing code paths, simplified the UI by eliminating the file upload/preset logic, and ensured download buttons appear only after generating a barcode. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f058e2dd948320aa2a93173a0e72ff)