### PR TITLE
新增條碼上下微調並套用至預覽與 PDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,12 @@
                 <button type="button" onclick="adjustBarcodeInset(-0.2)">＋</button>
                 <span style="font-size:12px;color:#718096;">（預設 11 x 35）</span>
             </div>
+            <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+                <span>上下微調</span>
+                <button type="button" onclick="adjustVerticalOffset(-0.2)">上移</button>
+                <span id="barcode-vertical-offset-display">0.6 mm</span>
+                <button type="button" onclick="adjustVerticalOffset(0.2)">下移</button>
+            </div>
             <div style="font-size:12px;color:#4a5568;margin-bottom:10px;">
                 目前可排版：<span id="layout-count-preview">0 欄 × 0 列</span>
             </div>
@@ -115,11 +121,14 @@
 const PAGE_WIDTH_MM = 102;
 const PAGE_HEIGHT_MM = 152;
 const DEFAULT_INSET_MM = 0.8;
+const DEFAULT_VERTICAL_OFFSET_MM = 0.6;
 let currentBarcodePngDataUrl = '';
 let barcodeInsetMm = DEFAULT_INSET_MM;
+let barcodeVerticalOffsetMm = DEFAULT_VERTICAL_OFFSET_MM;
 
 window.addEventListener('DOMContentLoaded', () => {
     updateInsetDisplay();
+    updateVerticalOffsetDisplay();
     onLabelSettingsChanged();
 });
 function handleEnter(e) {
@@ -197,6 +206,8 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
             const scaledHeightPx = Math.round((sourceHeight / sourceWidth) * targetWidthPx);
             const cropHeightPx = Math.round((targetHeightMm / targetWidthMm) * targetWidthPx);
             const cropTopPx = Math.max(0, scaledHeightPx - cropHeightPx);
+            const pxPerMm = targetWidthPx / targetWidthMm;
+            const verticalOffsetPx = Math.round(barcodeVerticalOffsetMm * pxPerMm);
             const canvas = document.createElement('canvas');
             canvas.width = targetWidthPx;
             canvas.height = cropHeightPx;
@@ -210,7 +221,7 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
                 sourceWidth,
                 sourceHeight,
                 0,
-                -cropTopPx,
+                -cropTopPx + verticalOffsetPx,
                 targetWidthPx,
                 scaledHeightPx
             );
@@ -395,6 +406,9 @@ function refreshPreviewBarcodePng() {
 function updateInsetDisplay() {
     document.getElementById('barcode-inset-display').textContent = `${barcodeInsetMm.toFixed(1)} mm`;
 }
+function updateVerticalOffsetDisplay() {
+    document.getElementById('barcode-vertical-offset-display').textContent = `${barcodeVerticalOffsetMm.toFixed(1)} mm`;
+}
 function getMaxInset(widthMm, heightMm) {
     return Math.max(0, Math.min(widthMm, heightMm) / 2 - 0.5);
 }
@@ -408,6 +422,12 @@ function adjustBarcodeInset(delta) {
     barcodeInsetMm = Math.round(nextInset * 10) / 10;
     updateInsetDisplay();
     renderLabelPreview();
+}
+function adjustVerticalOffset(delta) {
+    const nextOffset = Math.min(3, Math.max(-3, barcodeVerticalOffsetMm + delta));
+    barcodeVerticalOffsetMm = Math.round(nextOffset * 10) / 10;
+    updateVerticalOffsetDisplay();
+    refreshPreviewBarcodePng();
 }
 function onLabelSettingsChanged() {
     const label = getValidatedLabelSize();


### PR DESCRIPTION
### Motivation
- 使用者發現產生的標籤中條碼看起來靠上且底部留白較多，需要能調整條碼在貼紙內的垂直位置以改善視覺對齊。

### Description
- 新增預設垂直偏移常數 `DEFAULT_VERTICAL_OFFSET_MM` 及變數 `barcodeVerticalOffsetMm` 用以儲存垂直微調值。 
- 在標籤設定區新增 UI 控制元件和顯示元素 `上下微調` 與 `barcode-vertical-offset-display`，並提供 `adjustVerticalOffset` 與 `updateVerticalOffsetDisplay` 函式以進行及顯示調整。 
- 在 SVG→PNG 的繪製流程 `svgToCroppedPngDataUrl` 計算 `verticalOffsetPx` 並把它套用到 `drawImage` 的 Y 位置，確保預覽與 PDF 輸出位置一致。 
- 調整初始化流程在 `DOMContentLoaded` 時同步更新垂直偏移顯示並重新計算預覽。 

### Testing
- 執行搜尋驗證變數與函式存在且串接正確：`rg -n "vertical-offset|adjustVerticalOffset|DEFAULT_VERTICAL_OFFSET_MM|barcodeVerticalOffsetMm" index.html`，結果顯示相應項目，檢查成功。 
- 確認工作目錄與版本控制狀態：`git status --short` 顯示 `index.html` 已修改，檢查成功。 
- 已將修改加入版本控制並提交：`git add index.html && git commit -m "調整條碼上下留白並新增垂直微調控制"`，提交成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0675dbcb48320aa4fb3ce605918f8)