### PR TITLE
Change vertical fine-tune to downward-push control

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,10 +92,10 @@
                 <span style="font-size:12px;color:#718096;">（預設 11 x 35）</span>
             </div>
             <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
-                <span>上下微調</span>
-                <button type="button" onclick="adjustVerticalOffset(-0.2)">上移</button>
+                <span>整體下推</span>
+                <button type="button" onclick="adjustVerticalPush(-0.2)">減少</button>
                 <span id="barcode-vertical-offset-display">0.6 mm</span>
-                <button type="button" onclick="adjustVerticalOffset(0.2)">下移</button>
+                <button type="button" onclick="adjustVerticalPush(0.2)">增加</button>
             </div>
             <div style="font-size:12px;color:#4a5568;margin-bottom:10px;">
                 目前可排版：<span id="layout-count-preview">0 欄 × 0 列</span>
@@ -124,7 +124,7 @@ const DEFAULT_INSET_MM = 0.8;
 const DEFAULT_VERTICAL_OFFSET_MM = 0.6;
 let currentBarcodePngDataUrl = '';
 let barcodeInsetMm = DEFAULT_INSET_MM;
-let barcodeVerticalOffsetMm = DEFAULT_VERTICAL_OFFSET_MM;
+let barcodeVerticalPushMm = DEFAULT_VERTICAL_OFFSET_MM;
 
 window.addEventListener('DOMContentLoaded', () => {
     updateInsetDisplay();
@@ -207,7 +207,7 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
             const cropHeightPx = Math.round((targetHeightMm / targetWidthMm) * targetWidthPx);
             const cropTopPx = Math.max(0, scaledHeightPx - cropHeightPx);
             const pxPerMm = targetWidthPx / targetWidthMm;
-            const verticalOffsetPx = Math.round(barcodeVerticalOffsetMm * pxPerMm);
+            const verticalPushPx = Math.round(barcodeVerticalPushMm * pxPerMm);
             const canvas = document.createElement('canvas');
             canvas.width = targetWidthPx;
             canvas.height = cropHeightPx;
@@ -221,7 +221,7 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
                 sourceWidth,
                 sourceHeight,
                 0,
-                -cropTopPx + verticalOffsetPx,
+                -cropTopPx + verticalPushPx,
                 targetWidthPx,
                 scaledHeightPx
             );
@@ -407,7 +407,7 @@ function updateInsetDisplay() {
     document.getElementById('barcode-inset-display').textContent = `${barcodeInsetMm.toFixed(1)} mm`;
 }
 function updateVerticalOffsetDisplay() {
-    document.getElementById('barcode-vertical-offset-display').textContent = `${barcodeVerticalOffsetMm.toFixed(1)} mm`;
+    document.getElementById('barcode-vertical-offset-display').textContent = `${barcodeVerticalPushMm.toFixed(1)} mm`;
 }
 function getMaxInset(widthMm, heightMm) {
     return Math.max(0, Math.min(widthMm, heightMm) / 2 - 0.5);
@@ -423,9 +423,9 @@ function adjustBarcodeInset(delta) {
     updateInsetDisplay();
     renderLabelPreview();
 }
-function adjustVerticalOffset(delta) {
-    const nextOffset = Math.min(3, Math.max(-3, barcodeVerticalOffsetMm + delta));
-    barcodeVerticalOffsetMm = Math.round(nextOffset * 10) / 10;
+function adjustVerticalPush(delta) {
+    const nextPush = Math.min(6, Math.max(0, barcodeVerticalPushMm + delta));
+    barcodeVerticalPushMm = Math.round(nextPush * 10) / 10;
     updateVerticalOffsetDisplay();
     refreshPreviewBarcodePng();
 }


### PR DESCRIPTION
### Motivation

- Convert the existing up/down fine-tune control into a semantic "downward push" control so the label adjustment only moves the barcode downward. 
- Make the UI and internal state names clearly reflect the new downward-only behavior.

### Description

- Replaced the UI label and buttons for the vertical control from "上下微調" / `adjustVerticalOffset` (上移/下移) to "整體下推" with `adjustVerticalPush` (減少/增加). 
- Renamed the state from `barcodeVerticalOffsetMm` to `barcodeVerticalPushMm` and kept the same default value via `DEFAULT_VERTICAL_OFFSET_MM`.
- Updated the PNG cropping/drawing code to compute `verticalPushPx` and apply it when drawing the barcode for preview/PDF generation. 
- Restricted the push range to non-negative values (`0` to `6 mm`) in `adjustVerticalPush(delta)` so the barcode cannot be moved upward anymore.

### Testing

- Verified code references and replacements with `rg -n "adjustVerticalPush|barcodeVerticalPushMm|整體下推" index.html` and confirmed the new identifiers are present and consistent. 
- Inspected the modified regions with `nl -ba index.html` to ensure the UI, variable rename, drawing math, and handler changes were applied correctly; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f06c7c71e08320a7a137837d089254)