### PR TITLE
Handle barcode vertical offset in layout/preview instead of SVG rasterization

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,8 +206,6 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
             const scaledHeightPx = Math.round((sourceHeight / sourceWidth) * targetWidthPx);
             const cropHeightPx = Math.round((targetHeightMm / targetWidthMm) * targetWidthPx);
             const cropTopPx = Math.max(0, scaledHeightPx - cropHeightPx);
-            const pxPerMm = targetWidthPx / targetWidthMm;
-            const verticalOffsetPx = Math.round(barcodeVerticalOffsetMm * pxPerMm);
             const canvas = document.createElement('canvas');
             canvas.width = targetWidthPx;
             canvas.height = cropHeightPx;
@@ -221,7 +219,7 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
                 sourceWidth,
                 sourceHeight,
                 0,
-                -cropTopPx + verticalOffsetPx,
+                -cropTopPx,
                 targetWidthPx,
                 scaledHeightPx
             );
@@ -278,6 +276,7 @@ async function downloadLabelPdf() {
         imageWidth,
         imageHeight
     );
+    const normalVerticalShift = getVerticalShiftMm(imageHeight, normalPlacement.drawHeight);
     for (let row = 0; row < layoutPlan.portraitRows; row++) {
         for (let col = 0; col < layoutPlan.portraitCols; col++) {
             const x = marginX + col * barcodeWidth;
@@ -286,7 +285,7 @@ async function downloadLabelPdf() {
                 pngDataUrl,
                 'PNG',
                 x + safeInset + normalPlacement.offsetX,
-                y + safeInset + normalPlacement.offsetY,
+                y + safeInset + normalPlacement.offsetY + normalVerticalShift,
                 normalPlacement.drawWidth,
                 normalPlacement.drawHeight,
                 undefined,
@@ -308,6 +307,7 @@ async function downloadLabelPdf() {
             rotatedImageWidth,
             rotatedImageHeight
         );
+        const rotatedVerticalShift = getVerticalShiftMm(rotatedImageHeight, rotatedPlacement.drawHeight);
         for (let row = 0; row < layoutPlan.landscapeRows; row++) {
             for (let col = 0; col < layoutPlan.landscapeCols; col++) {
                 const x = layoutPlan.landscapeStartX + col * rotatedWidth;
@@ -316,7 +316,7 @@ async function downloadLabelPdf() {
                     rotatedPngDataUrl,
                     'PNG',
                     x + safeInset + rotatedPlacement.offsetX,
-                    y + safeInset + rotatedPlacement.offsetY,
+                    y + safeInset + rotatedPlacement.offsetY + rotatedVerticalShift,
                     rotatedPlacement.drawWidth,
                     rotatedPlacement.drawHeight,
                     undefined,
@@ -371,6 +371,11 @@ function getContainPlacement(sourceWidth, sourceHeight, boxWidth, boxHeight) {
         offsetX: (boxWidth - drawWidth) / 2,
         offsetY: (boxHeight - drawHeight) / 2
     };
+}
+function getVerticalShiftMm(containerHeight, drawHeight) {
+    const freeSpace = Math.max(0, containerHeight - drawHeight);
+    const maxShift = freeSpace / 2;
+    return Math.min(maxShift, Math.max(-maxShift, barcodeVerticalOffsetMm));
 }
 function getValidatedLabelSize(showAlert = false) {
     const widthMm = parseFloat(document.getElementById('label-width-mm').value);
@@ -427,7 +432,7 @@ function adjustVerticalOffset(delta) {
     const nextOffset = Math.min(3, Math.max(-3, barcodeVerticalOffsetMm + delta));
     barcodeVerticalOffsetMm = Math.round(nextOffset * 10) / 10;
     updateVerticalOffsetDisplay();
-    refreshPreviewBarcodePng();
+    renderLabelPreview();
 }
 function onLabelSettingsChanged() {
     const label = getValidatedLabelSize();
@@ -495,8 +500,11 @@ function renderLabelPreview() {
     previewBox.style.width = `${boxWidthPx}px`;
     previewBox.style.height = `${boxHeightPx}px`;
     const insetPx = Math.round(barcodeInsetMm * pxPerMm);
-    previewContent.style.width = `${Math.max(6, boxWidthPx - insetPx * 2)}px`;
-    previewContent.style.height = `${Math.max(6, boxHeightPx - insetPx * 2)}px`;
+    const contentWidthPx = Math.max(6, boxWidthPx - insetPx * 2);
+    const contentHeightPx = Math.max(6, boxHeightPx - insetPx * 2);
+    previewContent.style.width = `${contentWidthPx}px`;
+    previewContent.style.height = `${contentHeightPx}px`;
+    previewContent.style.transform = `translateY(${Math.round(barcodeVerticalOffsetMm * pxPerMm)}px)`;
     if (!currentBarcodePngDataUrl) {
         placeholder.textContent = '先按「產生條碼」';
         placeholder.style.display = 'block';


### PR DESCRIPTION
### Motivation

- Ensure the user-configurable vertical offset (`barcodeVerticalOffsetMm`) affects preview and PDF placement reliably without altering the underlying cropped PNG rasterization.
- Prevent the barcode PNG cropping step from embedding the vertical offset which caused placement/cropping inconsistencies.
- Apply a clamped vertical shift when composing images into the PDF so printed labels reflect the requested offset.

### Description

- Removed the direct use of `barcodeVerticalOffsetMm` inside `svgToCroppedPngDataUrl` so the rasterized PNG is a neutral crop without an embedded vertical offset.
- Added `getVerticalShiftMm(containerHeight, drawHeight)` to compute a clamped vertical shift and applied it as `normalVerticalShift` and `rotatedVerticalShift` when calling `pdf.addImage` for portrait and landscape placements respectively.
- Changed `adjustVerticalOffset` to call `renderLabelPreview()` instead of regenerating the PNG with `refreshPreviewBarcodePng()`, and made the preview reflect the offset by applying `transform: translateY(...)` to the preview content instead of changing the PNG.
- Minor preview refactor: extracted `contentWidthPx`/`contentHeightPx` variables and set preview element size from them.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f06c7c71e08320a7a137837d089254)