### PR TITLE
Add top-trim control and apply top trimming to barcode PNG export

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,10 +92,16 @@
                 <span style="font-size:12px;color:#718096;">（預設 11 x 35）</span>
             </div>
             <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
-                <span>整體下推</span>
+                <span>調整下緣</span>
                 <button type="button" onclick="adjustVerticalPush(-0.2)">減少</button>
                 <span id="barcode-vertical-offset-display">0.6 mm</span>
                 <button type="button" onclick="adjustVerticalPush(0.2)">增加</button>
+            </div>
+            <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+                <span>調整上緣</span>
+                <button type="button" onclick="adjustTopTrim(-0.2)">減少</button>
+                <span id="barcode-top-trim-display">0.0 mm</span>
+                <button type="button" onclick="adjustTopTrim(0.2)">增加</button>
             </div>
             <div style="font-size:12px;color:#4a5568;margin-bottom:10px;">
                 目前可排版：<span id="layout-count-preview">0 欄 × 0 列</span>
@@ -122,13 +128,16 @@ const PAGE_WIDTH_MM = 102;
 const PAGE_HEIGHT_MM = 152;
 const DEFAULT_INSET_MM = 0.8;
 const DEFAULT_VERTICAL_OFFSET_MM = 0.6;
+const DEFAULT_TOP_TRIM_MM = 0;
 let currentBarcodePngDataUrl = '';
 let barcodeInsetMm = DEFAULT_INSET_MM;
 let barcodeVerticalPushMm = DEFAULT_VERTICAL_OFFSET_MM;
+let barcodeTopTrimMm = DEFAULT_TOP_TRIM_MM;
 
 window.addEventListener('DOMContentLoaded', () => {
     updateInsetDisplay();
     updateVerticalOffsetDisplay();
+    updateTopTrimDisplay();
     onLabelSettingsChanged();
 });
 function handleEnter(e) {
@@ -208,6 +217,7 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
             const cropTopPx = Math.max(0, scaledHeightPx - cropHeightPx);
             const pxPerMm = targetWidthPx / targetWidthMm;
             const verticalPushPx = Math.round(barcodeVerticalPushMm * pxPerMm);
+            const topTrimPx = Math.round(barcodeTopTrimMm * pxPerMm);
             const canvas = document.createElement('canvas');
             canvas.width = targetWidthPx;
             canvas.height = cropHeightPx;
@@ -225,6 +235,9 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
                 targetWidthPx,
                 scaledHeightPx
             );
+            if (topTrimPx > 0) {
+                ctx.fillRect(0, 0, canvas.width, Math.min(canvas.height, topTrimPx));
+            }
             URL.revokeObjectURL(svgUrl);
             resolve(canvas.toDataURL('image/png'));
         };
@@ -409,6 +422,9 @@ function updateInsetDisplay() {
 function updateVerticalOffsetDisplay() {
     document.getElementById('barcode-vertical-offset-display').textContent = `${barcodeVerticalPushMm.toFixed(1)} mm`;
 }
+function updateTopTrimDisplay() {
+    document.getElementById('barcode-top-trim-display').textContent = `${barcodeTopTrimMm.toFixed(1)} mm`;
+}
 function getMaxInset(widthMm, heightMm) {
     return Math.max(0, Math.min(widthMm, heightMm) / 2 - 0.5);
 }
@@ -427,6 +443,12 @@ function adjustVerticalPush(delta) {
     const nextPush = Math.min(6, Math.max(0, barcodeVerticalPushMm + delta));
     barcodeVerticalPushMm = Math.round(nextPush * 10) / 10;
     updateVerticalOffsetDisplay();
+    refreshPreviewBarcodePng();
+}
+function adjustTopTrim(delta) {
+    const nextTrim = Math.min(4, Math.max(0, barcodeTopTrimMm + delta));
+    barcodeTopTrimMm = Math.round(nextTrim * 10) / 10;
+    updateTopTrimDisplay();
     refreshPreviewBarcodePng();
 }
 function onLabelSettingsChanged() {


### PR DESCRIPTION
### Motivation
- Provide a way to trim the top edge of rendered barcodes for label layout precision and to complement the existing vertical push/inset controls.
- Clarify a UI label by renaming the vertical control text from `整體下推` to `調整下緣` for clearer meaning.

### Description
- Introduce `DEFAULT_TOP_TRIM_MM` and `barcodeTopTrimMm` state and call `updateTopTrimDisplay()` on `DOMContentLoaded` to initialize the new control display.
- Add a new UI block with controls and a display element `barcode-top-trim-display` and implement `adjustTopTrim(delta)` to clamp and update the trim value and refresh the preview via `refreshPreviewBarcodePng()`.
- Apply top-trim cropping in `svgToCroppedPngDataUrl()` by computing `topTrimPx` and filling the top area when trimming is requested, and keep existing vertical push logic intact.
- Minor UI text change replacing the `整體下推` label with `調整下緣` in the form.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f070262a048320840cb11e1f4ffb15)