### PR TITLE
移除條碼下緣與上方留白調整功能

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,18 +91,6 @@
                 <button type="button" onclick="adjustBarcodeInset(-0.2)">＋</button>
                 <span style="font-size:12px;color:#718096;">（預設 11 x 35）</span>
             </div>
-            <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
-                <span>調整下緣</span>
-                <button type="button" onclick="adjustVerticalPush(-0.2)">減少</button>
-                <span id="barcode-vertical-offset-display">0.6 mm</span>
-                <button type="button" onclick="adjustVerticalPush(0.2)">增加</button>
-            </div>
-            <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
-                <span>上方留白</span>
-                <button type="button" onclick="adjustTopWhitespace(-0.2)">減少</button>
-                <span id="barcode-top-whitespace-display">0.0 mm</span>
-                <button type="button" onclick="adjustTopWhitespace(0.2)">增加</button>
-            </div>
             <div style="font-size:12px;color:#4a5568;margin-bottom:10px;">
                 目前可排版：<span id="layout-count-preview">0 欄 × 0 列</span>
             </div>
@@ -127,17 +115,13 @@
 const PAGE_WIDTH_MM = 102;
 const PAGE_HEIGHT_MM = 152;
 const DEFAULT_INSET_MM = 0.8;
-const DEFAULT_VERTICAL_OFFSET_MM = 0.6;
-const DEFAULT_TOP_WHITESPACE_MM = 0;
+const FIXED_VERTICAL_OFFSET_MM = 0.6;
+const FIXED_TOP_WHITESPACE_MM = 0;
 let currentBarcodePngDataUrl = '';
 let barcodeInsetMm = DEFAULT_INSET_MM;
-let barcodeVerticalPushMm = DEFAULT_VERTICAL_OFFSET_MM;
-let barcodeTopWhitespaceMm = DEFAULT_TOP_WHITESPACE_MM;
 
 window.addEventListener('DOMContentLoaded', () => {
     updateInsetDisplay();
-    updateVerticalOffsetDisplay();
-    updateTopWhitespaceDisplay();
     onLabelSettingsChanged();
 });
 function handleEnter(e) {
@@ -216,8 +200,8 @@ function svgToCroppedPngDataUrl(svg, targetWidthMm, targetHeightMm) {
             const cropHeightPx = Math.round((targetHeightMm / targetWidthMm) * targetWidthPx);
             const cropTopPx = Math.max(0, scaledHeightPx - cropHeightPx);
             const pxPerMm = targetWidthPx / targetWidthMm;
-            const verticalPushPx = Math.round(barcodeVerticalPushMm * pxPerMm);
-            const topWhitespacePx = Math.round(barcodeTopWhitespaceMm * pxPerMm);
+            const verticalPushPx = Math.round(FIXED_VERTICAL_OFFSET_MM * pxPerMm);
+            const topWhitespacePx = Math.round(FIXED_TOP_WHITESPACE_MM * pxPerMm);
             const scale = targetWidthPx / sourceWidth;
             const sourceTopCropPx = Math.min(sourceHeight - 1, Math.max(0, Math.round(topWhitespacePx / scale)));
             const drawHeightPx = Math.max(1, scaledHeightPx - topWhitespacePx);
@@ -419,12 +403,6 @@ function refreshPreviewBarcodePng() {
 function updateInsetDisplay() {
     document.getElementById('barcode-inset-display').textContent = `${barcodeInsetMm.toFixed(1)} mm`;
 }
-function updateVerticalOffsetDisplay() {
-    document.getElementById('barcode-vertical-offset-display').textContent = `${barcodeVerticalPushMm.toFixed(1)} mm`;
-}
-function updateTopWhitespaceDisplay() {
-    document.getElementById('barcode-top-whitespace-display').textContent = `${barcodeTopWhitespaceMm.toFixed(1)} mm`;
-}
 function getMaxInset(widthMm, heightMm) {
     return Math.max(0, Math.min(widthMm, heightMm) / 2 - 0.5);
 }
@@ -438,18 +416,6 @@ function adjustBarcodeInset(delta) {
     barcodeInsetMm = Math.round(nextInset * 10) / 10;
     updateInsetDisplay();
     renderLabelPreview();
-}
-function adjustVerticalPush(delta) {
-    const nextPush = Math.min(6, Math.max(0, barcodeVerticalPushMm + delta));
-    barcodeVerticalPushMm = Math.round(nextPush * 10) / 10;
-    updateVerticalOffsetDisplay();
-    refreshPreviewBarcodePng();
-}
-function adjustTopWhitespace(delta) {
-    const nextWhitespace = Math.min(4, Math.max(0, barcodeTopWhitespaceMm + delta));
-    barcodeTopWhitespaceMm = Math.round(nextWhitespace * 10) / 10;
-    updateTopWhitespaceDisplay();
-    refreshPreviewBarcodePng();
 }
 function onLabelSettingsChanged() {
     const label = getValidatedLabelSize();


### PR DESCRIPTION
### Motivation
- 使用者要求直接移除頁面上「調整下緣」與「上方留白」的可調整功能，改回固定的裁切/偏移行為以簡化介面與流程。

### Description
- 移除頁面 UI 中的「調整下緣」與「上方留白」控制區塊及其 DOM 元素顯示。
- 刪除對應的可調整狀態與函式：`adjustVerticalPush`、`adjustTopWhitespace`、`updateVerticalOffsetDisplay`、`updateTopWhitespaceDisplay`，並移除相關顯示 id。
- 新增固定常數 `FIXED_VERTICAL_OFFSET_MM` 與 `FIXED_TOP_WHITESPACE_MM`，並在 `svgToCroppedPngDataUrl` 中使用固定值取代可變偏移。
- 移除初始化時的顯示更新呼叫，並保留條碼內縮（`adjustBarcodeInset`）等其他功能不變。

### Testing
- 使用 `rg` 搜尋關鍵字以確認調整函式與 DOM id 已移除，搜尋確認無殘留（測試成功）。
- 使用 `git status --short` 確認檔案變更範圍僅為 `index.html`（測試成功）。
- `apply_patch`/變更檔案與提交操作均已成功執行（測試成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f0728794f48320a292f3079222fbc1)