### PR TITLE
調整條碼上方預設留白與內縮步進至 0.5mm/0.1mm

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,9 +86,9 @@
             </div>
             <div style="margin-bottom: 10px;display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
                 <span>條碼內縮</span>
-                <button type="button" onclick="adjustBarcodeInset(0.2)">－</button>
-                <span id="barcode-inset-display">0.8 mm</span>
-                <button type="button" onclick="adjustBarcodeInset(-0.2)">＋</button>
+                <button type="button" onclick="adjustBarcodeInset(0.1)">－</button>
+                <span id="barcode-inset-display">0.5 mm</span>
+                <button type="button" onclick="adjustBarcodeInset(-0.1)">＋</button>
                 <span style="font-size:12px;color:#718096;">（預設 11 x 35）</span>
             </div>
             <div style="font-size:12px;color:#4a5568;margin-bottom:10px;">
@@ -114,9 +114,9 @@
 <script>
 const PAGE_WIDTH_MM = 102;
 const PAGE_HEIGHT_MM = 152;
-const DEFAULT_INSET_MM = 0.8;
+const DEFAULT_INSET_MM = 0.5;
 const FIXED_VERTICAL_OFFSET_MM = 0.6;
-const FIXED_TOP_WHITESPACE_MM = 0;
+const FIXED_TOP_WHITESPACE_MM = 0.5;
 let currentBarcodePngDataUrl = '';
 let barcodeInsetMm = DEFAULT_INSET_MM;
 


### PR DESCRIPTION
### Motivation
- 讓產生的條碼預設不會緊貼上方邊界並提供更細緻的內縮微調，以改善列印與排版的外觀與可調整性。 

### Description
- 將 UI 上「條碼內縮」按鈕的調整步進從 `0.2 mm` 改為 `0.1 mm` 以支援更小幅度的微調。 
- 將顯示的預設內縮文字由 `0.8 mm` 改為 `0.5 mm`，並同步把程式常數 `DEFAULT_INSET_MM` 設為 `0.5`。 
- 將裁切時的預設上方留白常數 `FIXED_TOP_WHITESPACE_MM` 由 `0` 改為 `0.5`，避免條碼過於貼近上邊。 

### Testing
- 使用 `rg` 搜尋相關字串確認所有替換（`0.2` -> `0.1`、`0.8 mm` -> `0.5 mm`、`DEFAULT_INSET_MM`、`FIXED_TOP_WHITESPACE_MM`）已更新成功。 
- 已套用並驗證該補丁成功更新 `index.html`（檔案變更已寫入）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f074808cec832095de5f7611d4028c)